### PR TITLE
TRN-499: Makes code compatible with firebase/php-jwt v6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ composer.lock
 .idea
 src/storage
 .phpunit.result.cache
+# Sublime Text
+*.sublime-project
+*.sublime-workspace

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": ">=7.0.0",
         "cub/cub": "~0.1",
         "laravel/framework": "^8.0",
-        "firebase/php-jwt": "^5.0"
+        "firebase/php-jwt": "^6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0",

--- a/src/Cub/CubLaravel/Cub.php
+++ b/src/Cub/CubLaravel/Cub.php
@@ -15,6 +15,7 @@ use Cub_Object;
 use Cub_User;
 use Exception;
 use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Request;
 use Illuminate\Support\Str;
@@ -273,7 +274,10 @@ class Cub
             $token = $this->getRequestJWT();
         }
 
-        $decoded = (array) JWT::decode($token, config('cub.secret_key'), [self::ALGO]);
+        $decoded = (array) JWT::decode(
+            $token,
+            new Key(config('cub.secret_key'), self::ALGO)
+        );
 
         if (isset($decoded['scope'])) {
             throw new InvalidArgumentException('JWT scope claim can not be present.');
@@ -298,7 +302,10 @@ class Cub
         }
 
         try {
-            $decoded = (array) JWT::decode($jwt, config('cub.secret_key'), [self::ALGO]);
+            $decoded = (array) JWT::decode(
+                $jwt,
+                new Key(config('cub.secret_key'), self::ALGO)
+            );
 
             if (isset($decoded['scope'])) {
                 throw new InvalidArgumentException('JWT scope claim can not be present.');
@@ -384,7 +391,7 @@ class Cub
      */
     private function setCubUserCookie($token)
     {
-        JWT::decode($token, config('cub.secret_key'), [self::ALGO]);
+        JWT::decode($token, new Key(config('cub.secret_key'), self::ALGO));
 
         if (!headers_sent() && (!isset($_COOKIE[self::CUB_USER_COOKIE]) || $_COOKIE[self::CUB_USER_COOKIE] != $token)) {
             unset($_COOKIE[self::CUB_USER_COOKIE]);

--- a/tests/Cub/CubLaravel/Test/CubAuthMiddlewareTest.php
+++ b/tests/Cub/CubLaravel/Test/CubAuthMiddlewareTest.php
@@ -199,7 +199,7 @@ class CubAuthMiddlewareTest extends CubLaravelTestCase
         $token = [
             'user' => $this->details['id'],
         ];
-        $jwt = JWT::encode($token, 'giveme500!');
+        $jwt = JWT::encode($token, 'giveme500!', 'HS256');
 
         $actual = $this->get('restricted?cub_token='.$jwt);
 
@@ -219,7 +219,7 @@ class CubAuthMiddlewareTest extends CubLaravelTestCase
         $token = [
             'user' => $this->details['id'],
         ];
-        $jwt = JWT::encode($token, 'giveme500!');
+        $jwt = JWT::encode($token, 'giveme500!', 'HS256');
 
         $actual = $this->get('restricted', ['HTTP_Authorization' => 'Bearer '.$jwt]);
 

--- a/tests/Cub/CubLaravel/Test/CubLaravelTestCase.php
+++ b/tests/Cub/CubLaravel/Test/CubLaravelTestCase.php
@@ -130,6 +130,6 @@ abstract class CubLaravelTestCase extends TestCase
     {
         return JWT::encode(array_merge([
             'user' => $this->details['id'],
-        ], $payload), config('cub.secret_key'));
+        ], $payload), config('cub.secret_key'), 'HS256');
     }
 }

--- a/tests/Cub/CubLaravel/Test/FakeCubLogin.php
+++ b/tests/Cub/CubLaravel/Test/FakeCubLogin.php
@@ -24,7 +24,7 @@ class FakeCubLogin implements CubLogin
             'id' => 'usr_upfrcJvCTyXCVBj8',
             'token' => JWT::encode([
                 'user' => 'usr_upfrcJvCTyXCVBj8',
-            ], config('cub.secret_key')),
+            ], config('cub.secret_key'), 'HS256'),
         ]);
     }
 }


### PR DESCRIPTION
### **PR Type**
enhancement


___

### **Description**
- Update code for compatibility with firebase/php-jwt v6.0

- Refactor JWT decode/encode usage to new API

- Update tests to use new JWT encode signature

- Bump firebase/php-jwt dependency to ^6.0 in composer.json


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cub.php</strong><dd><code>Refactor JWT decode for php-jwt v6.0 compatibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Cub/CubLaravel/Cub.php

<li>Refactor JWT::decode calls to use new Key object<br> <li> Update all JWT decode usages for v6.0 compatibility


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/1/files#diff-725b8e3445c51655df854cd97a1ea76a218eaa3f22515837f6a3d5a7f723a2ce">+10/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CubAuthMiddlewareTest.php</strong><dd><code>Update JWT encode usage in tests for v6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Cub/CubLaravel/Test/CubAuthMiddlewareTest.php

<li>Update JWT::encode calls to include algorithm parameter<br> <li> Ensure test tokens are generated with explicit algorithm


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/1/files#diff-e781725b4337eaf20b169e7409b48ec40a6a831822a8d062324e2100dc6085cf">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CubLaravelTestCase.php</strong><dd><code>Update JWT encode in test helper for v6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Cub/CubLaravel/Test/CubLaravelTestCase.php

- Add algorithm parameter to JWT::encode in getToken helper


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/1/files#diff-aaa305f92817d143976313daaabfbd7a7136f7040d72666e407191ea05a0eb98">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>FakeCubLogin.php</strong><dd><code>Update JWT encode in fake login for v6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/Cub/CubLaravel/Test/FakeCubLogin.php

- Add algorithm parameter to JWT::encode in fake login


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/1/files#diff-6560dd5ec5bd8943cbddff2326a34c627a1cd7057ef3560d9265f0810c3857d7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>composer.json</strong><dd><code>Update firebase/php-jwt dependency to v6.0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

composer.json

- Bump firebase/php-jwt dependency from ^5.0 to ^6.0


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/1/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>