### PR TITLE
TRN-1056: Fixes PHP 8.1 TypeError compatibility issue

### DIFF
--- a/src/Cub/CubLaravel/Cub.php
+++ b/src/Cub/CubLaravel/Cub.php
@@ -89,7 +89,7 @@ class Cub
 
         $this->setCurrentUser($user);
         $this->setCurrentToken($cub_user->token);
-        
+
         if ($setCookie) {
             $this->setCubUserCookie($cub_user->token);
         }
@@ -112,7 +112,7 @@ class Cub
     public function check()
     {
         return (bool) $this->currentUser();
-    }    
+    }
 
     /**
      * @param \Illuminate\Database\Eloquent\Model|null $user
@@ -255,7 +255,7 @@ class Cub
         } else {
             $object = app()->make(config('cub.maps.'.$objectType.'.model'))->whereCubId($cubId)->first();
         }
-        
+
         if (!$object) {
             throw new ObjectNotFoundByCubIdException($cubId);
         }
@@ -347,7 +347,11 @@ class Cub
     {
         $authorization = $this->request->headers->get($header);
 
-        if (!Str::startsWith(strtolower($authorization), $method)) {
+        if (is_null($authorization)) {
+            return false;
+        }
+
+        if (! Str::startsWith(strtolower($authorization), $method)) {
             return false;
         }
 
@@ -359,7 +363,7 @@ class Cub
      *
      * @return false|string
      */
-    protected function getCubUserCookie() 
+    protected function getCubUserCookie()
     {
         if (!isset($_COOKIE[self::CUB_USER_COOKIE]) || $_COOKIE[self::CUB_USER_COOKIE] == '') {
             return false;
@@ -373,7 +377,7 @@ class Cub
      *
      * @return false|string
      */
-    protected function getCubOrgCookie() 
+    protected function getCubOrgCookie()
     {
         if (!isset($_COOKIE[self::CUB_ORG_COOKIE]) || $_COOKIE[self::CUB_ORG_COOKIE] == '') {
             return false;
@@ -563,7 +567,7 @@ class Cub
 
         return null;
     }
-    
+
     /**
      * @param \Illuminate\Database\Eloquent\Model $appObject
      * @param array $params


### PR DESCRIPTION
### **User description**
This pull request addresses a PHP 8.1 compatibility issue in Cub\CubLaravel\Cub::parseAuthHeader. In PHP 8.1, calling strtolower() with null raises a TypeError.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix PHP 8.1 TypeError in `parseAuthHeader` method

- Add null check before calling `strtolower()` function

- Clean up trailing whitespace formatting issues


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parseAuthHeader method"] --> B["Check if authorization is null"]
  B --> C["Return false if null"]
  B --> D["Continue with strtolower() if not null"]
  D --> E["Prevent TypeError in PHP 8.1"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Cub.php</strong><dd><code>Fix PHP 8.1 TypeError and formatting cleanup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Cub/CubLaravel/Cub.php

<ul><li>Add null check in <code>parseAuthHeader</code> method before calling <code>strtolower()</code><br> <li> Return false early if authorization header is null<br> <li> Remove trailing whitespace from multiple lines<br> <li> Fix code formatting and spacing issues</ul>


</details>


  </td>
  <td><a href="https://github.com/praetoriandigital/cub-laravel/pull/2/files#diff-725b8e3445c51655df854cd97a1ea76a218eaa3f22515837f6a3d5a7f723a2ce">+11/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

